### PR TITLE
build: add Docker image build workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,80 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*.*.*"]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - component: backend
+            context: ./backend
+            image: ghcr.io/bekkaze/abusebox-backend
+          - component: frontend
+            context: ./frontend
+            image: ghcr.io/bekkaze/abusebox-frontend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.image }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.component }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.component }}
+          provenance: true
+          sbom: true
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ matrix.image }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,10 +24,8 @@ jobs:
         include:
           - component: backend
             context: ./backend
-            image: ghcr.io/bekkaze/abusebox-backend
           - component: frontend
             context: ./frontend
-            image: ghcr.io/bekkaze/abusebox-frontend
 
     steps:
       - name: Checkout repository
@@ -50,7 +48,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ matrix.image }}
+          images: ghcr.io/${{ github.repository }}-${{ matrix.component }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=sha-
@@ -75,6 +73,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: ${{ matrix.image }}
+          subject-name: ghcr.io/${{ github.repository }}-${{ matrix.component }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   backend:
+    image: ghcr.io/${GHCR_REPO:-bekkaze/abusebox}-backend:latest
     build: ./backend
     env_file:
       - path: .env
@@ -16,6 +17,7 @@ services:
     ports:
       - 8100:8100
   frontend:
+    image: ghcr.io/${GHCR_REPO:-bekkaze/abusebox}-frontend:latest
     build: ./frontend
     depends_on:
       - backend


### PR DESCRIPTION
This PR adds Github Actions for building Docker images with attestation and updates docker-compose.yml file to use images from GHCR.

Test build run succeeded: https://github.com/zolbooo/abusebox/actions/runs/23540460170

`docker compose up -d` now downloads an image and runs it:
<img width="1512" height="908" alt="Screenshot 2026-03-25 at 21 32 47" src="https://github.com/user-attachments/assets/1662fdc7-de8e-41f3-8dd3-2d9eb026a114" />
